### PR TITLE
CSS override for D2-ui DataTable component

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -47,10 +47,11 @@ module.exports = {
   appIndexJs: resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
+  customCss: resolveApp('src/custom-css'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp('node_modules'),
-    appD2UINodeModules: resolveApp('node_modules/d2-ui'),
+  appD2UINodeModules: resolveApp('node_modules/d2-ui'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
 };

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -159,6 +159,7 @@ module.exports = {
           {
             test: /\.css$/,
               include: paths.appSrc,
+              exclude: paths.customCss,
               use: [
               require.resolve('style-loader'),
               {
@@ -195,7 +196,7 @@ module.exports = {
             {
 
                 test: /\.css$/,
-                include: paths.appD2UINodeModules,
+                include: [paths.appD2UINodeModules, paths.customCss],
                 loader: 'style-loader!css-loader',
             },
           // "file" loader makes sure those assets get served by WebpackDevServer.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -167,6 +167,8 @@ module.exports = {
           // in the main CSS file.
           {
             test: /\.css$/,
+            include: paths.appSrc,
+            exclude: paths.customCss,
             loader: ExtractTextPlugin.extract(
               Object.assign(
                 {
@@ -211,8 +213,16 @@ module.exports = {
                 extractTextPluginOptions
               )
             ),
+
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
+            // Process css
+            {
+
+                test: /\.css$/,
+                include: [paths.appD2UINodeModules, paths.customCss],
+                loader: 'style-loader!css-loader',
+            },
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.
           // This loader doesn't use a "test" so it will catch all modules

--- a/i18n/translations.pot
+++ b/i18n/translations.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-02-20T12:18:05.543Z\n"
-"PO-Revision-Date: 2018-02-20T12:18:05.543Z\n"
+"POT-Creation-Date: 2018-02-21T08:57:47.291Z\n"
+"PO-Revision-Date: 2018-02-21T08:57:47.291Z\n"
 
 msgid "Close"
 msgstr ""
@@ -26,64 +26,10 @@ msgstr ""
 msgid "An unexpected error happened during operation"
 msgstr ""
 
-msgid "Performing Maintenance"
-msgstr ""
-
-msgid "Maintenance done"
-msgstr ""
-
-msgid "An unexpected error happend during maintenance"
-msgstr ""
-
-msgid "Select all"
-msgstr ""
-
-msgid "PERFORM MAINTENANCE"
-msgstr ""
-
-msgid "It was not possible to load data"
-msgstr ""
-
-msgid "Select Data set and Organisation Unit"
-msgstr ""
-
-msgid "Doing Min Max generation"
-msgstr ""
-
-msgid "Min Max generation done"
-msgstr ""
-
-msgid "It was not possible to do your request"
-msgstr ""
-
-msgid "Removing Min Max generation"
-msgstr ""
-
-msgid "Min Max removal done"
+msgid "Select a Data Set"
 msgstr ""
 
 msgid "Data Set"
-msgstr ""
-
-msgid "Loading data sets"
-msgstr ""
-
-msgid "Organisation Unit Selection"
-msgstr ""
-
-msgid "Updating Organisation Units Tree..."
-msgstr ""
-
-msgid "GENERATE"
-msgstr ""
-
-msgid "REMOVE"
-msgstr ""
-
-msgid "An unexpected error happened during operation"
-msgstr ""
-
-msgid "Select a Data Set"
 msgstr ""
 
 msgid "Updating Tree..."

--- a/src/custom-css/D2UIDataTableOverrides.css
+++ b/src/custom-css/D2UIDataTableOverrides.css
@@ -1,0 +1,8 @@
+.data-table__context-menu__item div, .data-table__rows__row__column {
+    font-size: 14px;
+    font-family: 'Roboto', sans-serif;
+}
+
+.data-table__headers__header {
+    font-family: 'Roboto', sans-serif;
+}

--- a/src/pages/lock-exception/LockException.js
+++ b/src/pages/lock-exception/LockException.js
@@ -24,6 +24,8 @@ import LockExceptionDetails from './LockExceptionDetails';
 import { PAGE_SUMMARY, PAGE_TITLE } from './lock.exception.conf';
 import PageHelper from '../../components/page-helper/PageHelper';
 
+import '../../custom-css/D2UIDataTableOverrides.css';
+
 const jsStyles = {
     dialog: {
         maxWidth: '80%',


### PR DESCRIPTION
@MDHomem review it, please.
I need a way to override css from DataTable component. For that I needed to update webpack build due to postcss. I could not find a way to do it using material-ui theme.

Just let me know if you have a better idea.

This code is to solve this [issue](http://jira.cadsh.com/browse/DHIS2OUT-54).