### PR TITLE
Dhis2 7223 analytics run never reported finished

### DIFF
--- a/src/components/notifications-table/NotificationsTable.js
+++ b/src/components/notifications-table/NotificationsTable.js
@@ -12,8 +12,9 @@ import {
     notificationStylesInfo,
     formatDateFromServer,
 } from './notifications-table.conf'
+import './style.css'
 
-const NotificationsTable = ({ notifications }) => {
+const NotificationsTable = ({ notifications, animateIncomplete }) => {
     const renderNotificationIcon = notification => {
         const notificationIconInfo = notificationStylesInfo[notification.level]
         if (
@@ -30,6 +31,8 @@ const NotificationsTable = ({ notifications }) => {
                     {notificationIconInfo.icon}
                 </FontIcon>
             )
+        } else if (animateIncomplete && !notification.completed) {
+            return <span className="notification-icon-busy">...</span>
         }
 
         return null

--- a/src/components/notifications-table/style.css
+++ b/src/components/notifications-table/style.css
@@ -8,6 +8,6 @@
 
 @keyframes ellipsis {
     to {
-        width: 12px;
+        width: 14px;
     }
 }

--- a/src/components/notifications-table/style.css
+++ b/src/components/notifications-table/style.css
@@ -1,0 +1,13 @@
+.notification-icon-busy {
+    overflow: hidden;
+    display: inline-block;
+    vertical-align: bottom;
+    animation: ellipsis steps(4, end) 1500ms infinite;
+    width: 0px;
+}
+
+@keyframes ellipsis {
+    to {
+        width: 12px;
+    }
+}

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -54,7 +54,6 @@ class Analytics extends Page {
             lastYears: DEFAULT_LAST_YEARS,
             notifications: [],
             intervalId: null,
-            allCompleted: false,
         }
 
         this.initAnalyticsTablesGeneration = this.initAnalyticsTablesGeneration.bind(

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -189,30 +189,22 @@ class Analytics extends Page {
         this.context.updateAppState({
             showSnackbar: !completed,
             pageState: {
-                notifications: this.getUpdatedNotifications(
-                    taskSummary,
-                    completed
-                ),
+                notifications: this.getUpdatedNotifications(taskSummary),
                 loading: !completed,
             },
         })
     }
 
-    getUpdatedNotifications(taskSummary = [], allCompleted) {
+    getUpdatedNotifications(taskSummary = []) {
         if (taskSummary.length <= this.state.notifications.length) {
             return this.state.notifications
         }
 
-        const currentNotificationLookup = new Set(
-            this.state.notifications.map(x => x.uid)
-        )
+        const lastIndex = taskSummary.length - 1
 
-        return taskSummary.reverse().map(x => ({
+        return taskSummary.reverse().map((x, i) => ({
             ...x,
-            completed:
-                allCompleted ||
-                currentNotificationLookup.has(x.uid) ||
-                x.completed,
+            completed: x.completed || i < lastIndex,
         }))
     }
 

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -36,7 +36,6 @@ class Analytics extends Page {
         'loading',
         'lastYears',
         'notifications',
-        'jobId',
         'intervalId',
     ]
 
@@ -54,8 +53,8 @@ class Analytics extends Page {
             loading: false,
             lastYears: DEFAULT_LAST_YEARS,
             notifications: [],
-            jobId: null,
             intervalId: null,
+            allCompleted: false,
         }
 
         this.initAnalyticsTablesGeneration = this.initAnalyticsTablesGeneration.bind(
@@ -147,7 +146,7 @@ class Analytics extends Page {
         return formData
     }
 
-    isAnalyzingTables = () => this.state.jobId && this.state.intervalId
+    isAnalyzingTables = () => !!this.state.intervalId
 
     startsPooling = () =>
         setInterval(() => {
@@ -165,11 +164,9 @@ class Analytics extends Page {
         api.post(ANALYTICS_TABLES_ENDPOINT, formData)
             .then(response => {
                 if (this.isPageMounted() && response) {
-                    const jobId = response.response.id
                     const intervalId = this.startsPooling()
 
                     this.setState({
-                        jobId,
                         intervalId,
                     })
                 }
@@ -182,8 +179,8 @@ class Analytics extends Page {
     }
 
     updateStateForInProgressJobAccordingTaskSummaryResponse = taskSummaryResponse => {
-        const notifications = taskSummaryResponse[this.state.jobId] || []
-        const completed = !this.isJobInProgress(notifications)
+        const taskSummary = taskSummaryResponse || []
+        const completed = !this.isJobInProgress(taskSummary)
 
         if (completed) {
             this.cancelPoollingRequests()
@@ -192,54 +189,55 @@ class Analytics extends Page {
         this.context.updateAppState({
             showSnackbar: !completed,
             pageState: {
-                notifications,
+                notifications: this.getUpdatedNotifications(
+                    taskSummary,
+                    completed
+                ),
                 loading: !completed,
             },
         })
     }
 
+    getUpdatedNotifications(taskSummary = [], allCompleted) {
+        if (taskSummary.length <= this.state.notifications.length) {
+            return this.state.notifications
+        }
+
+        const currentNotificationLookup = new Set(
+            this.state.notifications.map(x => x.uid)
+        )
+
+        return taskSummary.reverse().map(x => ({
+            ...x,
+            completed:
+                allCompleted ||
+                currentNotificationLookup.has(x.uid) ||
+                x.completed,
+        }))
+    }
+
     verifyInProgressJobsForTaskSummaryResponseAndUpdateState = taskSummaryResponse => {
-        const jobIds = taskSummaryResponse
-            ? Object.keys(taskSummaryResponse)
-            : []
+        if (taskSummaryResponse && this.isJobInProgress(taskSummaryResponse)) {
+            const intervalId = this.startsPooling()
 
-        // looking for the most recent in progress job
-        for (let i = jobIds.length - 1; i >= 0; i--) {
-            const jobId = jobIds[i]
-            const notifications = taskSummaryResponse[jobId] || []
-
-            // found in progress job: show current notifications and starts pooling
-            if (this.isJobInProgress(notifications)) {
-                const intervalId = this.startsPooling()
-
-                this.context.updateAppState({
-                    showSnackbar: true,
-                    snackbarConf: {
-                        type: LOADING,
-                    },
-                    pageState: {
-                        notifications,
-                        loading: true,
-                        jobId,
-                        intervalId,
-                    },
-                })
-
-                break
-            }
+            this.context.updateAppState({
+                showSnackbar: true,
+                snackbarConf: {
+                    type: LOADING,
+                },
+                pageState: {
+                    notifications: taskSummaryResponse.reverse(),
+                    loading: true,
+                    intervalId,
+                },
+            })
         }
     }
 
     requestTaskSummary() {
         const api = this.context.d2.Api.getApi()
-        const lastId =
-            this.state.notifications && this.state.notifications.length > 0
-                ? this.state.notifications[0].uid
-                : null
-        const url = lastId
-            ? `${ANALYTIC_TABLES_TASK_SUMMARY_ENDPOINT}?lastId=${lastId}`
-            : `${ANALYTIC_TABLES_TASK_SUMMARY_ENDPOINT}`
-        api.get(url)
+
+        api.get(ANALYTIC_TABLES_TASK_SUMMARY_ENDPOINT)
             .then(taskSummaryResponse => {
                 /* not mounted finishes */
                 if (!this.isPageMounted()) {
@@ -351,6 +349,7 @@ class Analytics extends Page {
                         <CardText>
                             <NotificationsTable
                                 notifications={this.state.notifications}
+                                animateIncomplete
                             />
                         </CardText>
                     </Card>

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -153,6 +153,7 @@ class Analytics extends Page {
         }, PULL_INTERVAL)
 
     isJobInProgress = jobNotifications =>
+        // When the most recent job comes back as completed the whole process is done
         jobNotifications.every(notification => !notification.completed)
 
     initAnalyticsTablesGeneration() {
@@ -195,12 +196,18 @@ class Analytics extends Page {
     }
 
     getUpdatedNotifications(taskSummary = []) {
+        // Notification table needs to be updated when new tasks are added
         if (taskSummary.length <= this.state.notifications.length) {
             return this.state.notifications
         }
 
         const lastIndex = taskSummary.length - 1
 
+        // Reverse to sort oldest-newest
+        // Assumption: all tasks are completed, apart from the last one,
+        // which is the in-progress task.
+        // Exception is when the most recent task comes back as completed
+        // this indicates the entire process is done, so we respect that completed status.
         return taskSummary.reverse().map((x, i) => ({
             ...x,
             completed: x.completed || i < lastIndex,
@@ -217,6 +224,7 @@ class Analytics extends Page {
                     type: LOADING,
                 },
                 pageState: {
+                    // reverse to sort oldest-newest
                     notifications: taskSummaryResponse.reverse(),
                     loading: true,
                     intervalId,

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -132,6 +132,7 @@ class ResourceTable extends Page {
     }
 
     updateStateForInProgressJobAccordingTaskSummaryResponse = taskSummaryResponse => {
+        // reverse to sort oldest-newest
         const notifications = (taskSummaryResponse || []).reverse()
         const completed = !this.isJobInProgress(notifications)
 
@@ -142,6 +143,9 @@ class ResourceTable extends Page {
         this.context.updateAppState({
             showSnackbar: !completed,
             pageState: {
+                // This process only has 2 steps. When the first comes in
+                // it is effectively the in-progress task
+                // When the process is completed we mark both steps as completed
                 notifications: !completed
                     ? notifications
                     : notifications.map(x => ({ ...x, completed: true })),
@@ -161,6 +165,7 @@ class ResourceTable extends Page {
                     type: LOADING,
                 },
                 pageState: {
+                    // reverse to sort oldest-newest
                     notifications: taskSummary.reverse(),
                     loading: true,
                     intervalId,

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -20,12 +20,7 @@ import pageStyles from '../Page.module.css'
 import styles from './ResourceTables.module.css'
 
 class ResourceTable extends Page {
-    static STATE_PROPERTIES = [
-        'loading',
-        'notifications',
-        'jobId',
-        'intervalId',
-    ]
+    static STATE_PROPERTIES = ['loading', 'notifications', 'intervalId']
 
     constructor() {
         super()
@@ -33,7 +28,6 @@ class ResourceTable extends Page {
         this.state = {
             loading: false,
             notifications: [],
-            jobId: null,
             intervalId: null,
         }
 
@@ -105,7 +99,7 @@ class ResourceTable extends Page {
         })
     }
 
-    isAnalyzingTables = () => this.state.jobId && this.state.intervalId
+    isAnalyzingTables = () => this.state.intervalId
 
     startsPooling = () =>
         setInterval(() => {
@@ -121,13 +115,11 @@ class ResourceTable extends Page {
         api.post(RESOURCE_TABLES_ENDPOINT)
             .then(response => {
                 if (this.isPageMounted() && response) {
-                    const jobId = response.response.id
                     const intervalId = setInterval(() => {
                         this.requestTaskSummary()
                     }, PULL_INTERVAL)
 
                     this.setState({
-                        jobId,
                         intervalId,
                     })
                 }
@@ -140,7 +132,7 @@ class ResourceTable extends Page {
     }
 
     updateStateForInProgressJobAccordingTaskSummaryResponse = taskSummaryResponse => {
-        const notifications = taskSummaryResponse[this.state.jobId] || []
+        const notifications = (taskSummaryResponse || []).reverse()
         const completed = !this.isJobInProgress(notifications)
 
         if (completed) {
@@ -150,55 +142,37 @@ class ResourceTable extends Page {
         this.context.updateAppState({
             showSnackbar: !completed,
             pageState: {
-                notifications,
+                notifications: !completed
+                    ? notifications
+                    : notifications.map(x => ({ ...x, completed: true })),
                 loading: !completed,
             },
         })
     }
 
     verifyInProgressJobsForTaskSummaryResponseAndUpdateState = taskSummaryResponse => {
-        const jobIds = taskSummaryResponse
-            ? Object.keys(taskSummaryResponse)
-            : []
+        const taskSummary = taskSummaryResponse || []
+        if (taskSummaryResponse && this.isJobInProgress(taskSummary)) {
+            const intervalId = this.startsPooling()
 
-        // looking for the most recent in progress job
-        for (let i = jobIds.length - 1; i >= 0; i--) {
-            const jobId = jobIds[i]
-            const notifications = taskSummaryResponse[jobId] || []
-
-            // found in progress job: show current notifications and starts pooling
-            if (this.isJobInProgress(notifications)) {
-                const intervalId = this.startsPooling()
-
-                this.context.updateAppState({
-                    showSnackbar: true,
-                    snackbarConf: {
-                        type: LOADING,
-                    },
-                    pageState: {
-                        notifications,
-                        loading: true,
-                        jobId,
-                        intervalId,
-                    },
-                })
-
-                break
-            }
+            this.context.updateAppState({
+                showSnackbar: true,
+                snackbarConf: {
+                    type: LOADING,
+                },
+                pageState: {
+                    notifications: taskSummary.reverse(),
+                    loading: true,
+                    intervalId,
+                },
+            })
         }
     }
 
     requestTaskSummary() {
         const api = this.context.d2.Api.getApi()
-        const lastId =
-            this.state.notifications && this.state.notifications.length > 0
-                ? this.state.notifications[0].uid
-                : null
-        const url = lastId
-            ? `${RESOURCE_TABLES_TASK_SUMMARY_ENDPOINT}?lastId=${lastId}`
-            : `${RESOURCE_TABLES_TASK_SUMMARY_ENDPOINT}`
 
-        api.get(url)
+        api.get(RESOURCE_TABLES_TASK_SUMMARY_ENDPOINT)
             .then(taskSummaryResponse => {
                 /* not mounted finishes */
                 if (!this.isPageMounted()) {
@@ -357,6 +331,7 @@ class ResourceTable extends Page {
                         <CardText>
                             <NotificationsTable
                                 notifications={this.state.notifications}
+                                animateIncomplete
                             />
                         </CardText>
                     </Card>


### PR DESCRIPTION
There has been an API change:
PRE: Calls to `system/tasks/{task-category-id}` would return an object with `jobId` keys, and the app would check if there was an active job
POST: Calls to `system/tasks/{task-category-id}` only return something if there is an active job. The app just assumes that is the only active job around.

So due to this API change I have removed the part of the code dealing with `jobId` in the analytics table and resource-tables section.

However, there was also something fishy going on with the NotificationTable (i.e. the "activity log"). I'm not sure whether this was also a result of an API change or if this always worked like this:
- Every task has a `completed` property
- But only the last task ever gets to have that property set to true, and this indicates that the entire process is completed
- So as a result none of the "sub-tasks" ever get completed status in the UI

I did notice a pattern here though:
- The task array grows periodically, i.e. poll-attempt 1-10 could contain 2 items, attempt 11-17 would get 11 items, attempt 18-24 would get 20 items, etc...
- Whenever this happens, we could interpret that as a clue that the process has moved on to the next batch of tasks

So I am now leveraging this pattern to display better notification rows. When a bunch of new tasks comes in, I am setting the current notification rows to `completed: true`. I also included an animated ellipsis in the notification rows to show the tasks is "in-progress". Now you can actually follow the progress of tasks in the notification table.

I also chose to reverse the notification array before displaying it, because it comes back from the API with the most recent first, but since this is a list of items that grows, it makes a lot more sense to have the oldest one first....