### PR TITLE
fix: no active jobs when empty array is returned

### DIFF
--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -215,7 +215,11 @@ class Analytics extends Page {
     }
 
     verifyInProgressJobsForTaskSummaryResponseAndUpdateState = taskSummaryResponse => {
-        if (taskSummaryResponse && this.isJobInProgress(taskSummaryResponse)) {
+        if (
+            taskSummaryResponse &&
+            taskSummaryResponse.length &&
+            this.isJobInProgress(taskSummaryResponse)
+        ) {
             const intervalId = this.startsPooling()
 
             this.context.updateAppState({

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -156,7 +156,11 @@ class ResourceTable extends Page {
 
     verifyInProgressJobsForTaskSummaryResponseAndUpdateState = taskSummaryResponse => {
         const taskSummary = taskSummaryResponse || []
-        if (taskSummaryResponse && this.isJobInProgress(taskSummary)) {
+        if (
+            taskSummaryResponse &&
+            taskSummaryResponse.length &&
+            this.isJobInProgress(taskSummary)
+        ) {
             const intervalId = this.startsPooling()
 
             this.context.updateAppState({


### PR DESCRIPTION
Small addition to the work I did earlier. I did not experience this problem locally, but remotely, you sometimes get back an empty array when calling the tasks endpoint. This also means there are no active jobs. 