### PR TITLE
fix(assets): bundle material design and typeface-roboto (DHIS2-7625)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,3 @@
-@import "~typeface-roboto/index.css";
-@import "~material-design-icons-iconfont/dist/material-design-icons.css";
-
 html {
     background: #f3f3f3;
     font-family: 'Roboto', sans-serif;
@@ -17,28 +14,4 @@ h1 {
     font-weight: 300;
     letter-spacing: 1.2px;
     color: rgba(0, 0, 0, 0.87);
-}
-
-.material-icons {
-    font-family: 'Material Icons';
-    font-weight: normal;
-    font-style: normal;
-    font-size: 24px; /* Preferred icon size */
-    display: inline-block;
-    line-height: 1;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
-    /* Support for all WebKit browsers. */
-    -webkit-font-smoothing: antialiased;
-    /* Support for Safari and Chrome. */
-    text-rendering: optimizeLegibility;
-    /* Support for Firefox. */
-    -moz-osx-font-smoothing: grayscale;
-    /* Support for IE. */
-    -webkit-font-feature-settings: 'liga';
-    font-feature-settings: 'liga';
-    font-display: block;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ import { configI18n } from './configI18n'
 import App from './App'
 import appTheme from './theme'
 import * as serviceWorker from './serviceWorker'
+
+import 'material-design-icons-iconfont/dist/material-design-icons.css'
+import 'typeface-roboto'
 import './index.css'
 
 const { NODE_ENV, REACT_APP_DHIS2_BASE_URL } = process.env


### PR DESCRIPTION
This issue was triggered by a problem in v31, so it won't actually fix anything here. However, we want all our apps to bundle all of their assets, so I am making this change here and then backport all the way up to v31.