### PR TITLE
fix: add programIndicatorsWithNoExpression integrity check, avoid crash [DHIS2-9702]

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -107,6 +107,9 @@ export const i18nKeys = {
         programRuleActionsWithNoStageId: {
             label: 'Program rule actions with no stage id',
         },
+        programIndicatorsWithNoExpression: {
+            label: 'Program indicators wit no expression',
+        },
     },
     maintenance: {
         title: 'Maintenance',

--- a/src/pages/data-integrity/DataIntegrity.js
+++ b/src/pages/data-integrity/DataIntegrity.js
@@ -156,12 +156,14 @@ class DataIntegrity extends Page {
                 if (!control) {
                     return null
                 }
-                return <DataIntegrityCard
-                    cardId={`errorElement-${element}`}
-                    key={element}
-                    title={control.label}
-                    content={this.state.cards[element]}
-                />
+                return (
+                    <DataIntegrityCard
+                        cardId={`errorElement-${element}`}
+                        key={element}
+                        title={control.label}
+                        content={this.state.cards[element]}
+                    />
+                )
             })
             if (this.state.loaded) {
                 const noErrors = conf.dataIntegrityControls

--- a/src/pages/data-integrity/DataIntegrity.js
+++ b/src/pages/data-integrity/DataIntegrity.js
@@ -149,18 +149,20 @@ class DataIntegrity extends Page {
         let cardsToShow = []
         if (this.state.cards) {
             const errorElementskeys = Object.keys(this.state.cards)
-            cardsToShow = errorElementskeys.map(element => (
-                <DataIntegrityCard
+            cardsToShow = errorElementskeys.map(element => {
+                const control = conf.dataIntegrityControls.find(
+                    control => control.key === element
+                )
+                if (!control) {
+                    return null
+                }
+                return <DataIntegrityCard
                     cardId={`errorElement-${element}`}
                     key={element}
-                    title={
-                        conf.dataIntegrityControls.find(
-                            control => control.key === element
-                        ).label
-                    }
+                    title={control.label}
                     content={this.state.cards[element]}
                 />
-            ))
+            })
             if (this.state.loaded) {
                 const noErrors = conf.dataIntegrityControls
                     .filter(

--- a/src/pages/data-integrity/data.integrity.conf.js
+++ b/src/pages/data-integrity/data.integrity.conf.js
@@ -183,5 +183,5 @@ export const dataIntegrityControls = [
     {
         key: 'programIndicatorsWithNoExpression',
         label: i18nKeys.dataIntegrity.programIndicatorsWithNoExpression.label,
-    }
+    },
 ]

--- a/src/pages/data-integrity/data.integrity.conf.js
+++ b/src/pages/data-integrity/data.integrity.conf.js
@@ -180,4 +180,8 @@ export const dataIntegrityControls = [
         key: 'programRuleActionsWithNoStageId',
         label: i18nKeys.dataIntegrity.programRuleActionsWithNoStageId.label,
     },
+    {
+        key: 'programIndicatorsWithNoExpression',
+        label: i18nKeys.dataIntegrity.programIndicatorsWithNoExpression.label,
+    }
 ]


### PR DESCRIPTION
This adds the missing `programIndicatorsWithNoExpression` integrity check.  It also avoids an `undefined` reference crash if an integrity check is found which doesn't have a locally-defined representation.

Notes:
1. The translations for the label will need to be added later (it's not clear how that's done in this app... if at all)
2. It would be better to show the integrity check failure even if it's not found in the local code
3. There's unnecessary duplication (and superfluous `.text` references which don't exist) between `DataIntegrity.conf.js` and `i18n.js`, but I decided not to refactor that here.