### PR TITLE
fix(lock exception): keep pager in state when navigating to batch delete

### DIFF
--- a/src/pages/lock-exception/LockException.js
+++ b/src/pages/lock-exception/LockException.js
@@ -387,6 +387,7 @@ class LockException extends Page {
         const api = this.context.d2.Api.getApi()
         const url =
             'lockExceptions/combinations?fields=name, period[id,displayName], dataSet[id,displayName]'
+        const pager = this.props.pager
 
         // request to GET lock exception combinations
         this.context.updateAppState({
@@ -399,6 +400,7 @@ class LockException extends Page {
                 atBatchDeletionPage: true,
                 loaded: false,
                 loading: true,
+                pager,
             },
         })
 
@@ -414,6 +416,7 @@ class LockException extends Page {
                                 response.lockExceptions
                             ),
                             loading: false,
+                            pager,
                         },
                     })
                 }


### PR DESCRIPTION
Fixes DHIS2-10914

When displaying the batch deletion page, the pager object was removed from the app state, which caused the bug.
I added the pager to the app state when clicking on the batch delete button