### PR TITLE
fix: revert data sets API periodType schema fix

### DIFF
--- a/src/pages/lock-exception/AddLockExceptionForm.js
+++ b/src/pages/lock-exception/AddLockExceptionForm.js
@@ -241,7 +241,7 @@ class AddLockExceptionForm extends Component {
         const dataSetItems = this.props.dataSets.map(dataSet => ({
             id: dataSet.id,
             name: dataSet.displayName,
-            periodType: dataSet.periodType.name,
+            periodType: dataSet.periodType,
         }))
 
         let dataSetSelectLabel = i18n.t('Select a data set')


### PR DESCRIPTION
The [schema of the data sets API was changed accidentally](https://jira.dhis2.org/browse/DHIS2-11198), resulting in the `periodType` field changing from being a string to an object of shape `{ name: String }`.

Now that [the issue  has been fixed](https://github.com/dhis2/dhis2-core/pull/8162), the temporary client-side fix can be reverted.