### PR TITLE
fix: show progress of existing analytics and resource tables tasks

### DIFF
--- a/src/components/NotificationsTable/NotificationsTable.js
+++ b/src/components/NotificationsTable/NotificationsTable.js
@@ -15,10 +15,6 @@ import {
 import styles from './NotificationsTable.module.css'
 
 const NotificationsTable = ({ notifications, animateIncomplete }) => {
-    // We use `some` here instead of e.g. `last(notifications).completed` as the
-    // order of the responses returned by the task APIs has been reversed in the past
-    // and this may reoccur in the future.
-    const done = notifications.some(n => n.completed)
     const renderNotificationIcon = notification => {
         const notificationIconInfo = notificationStylesInfo[notification.level]
         if (
@@ -35,7 +31,7 @@ const NotificationsTable = ({ notifications, animateIncomplete }) => {
                     {notificationIconInfo.icon}
                 </FontIcon>
             )
-        } else if (animateIncomplete && !notification.completed && !done) {
+        } else if (animateIncomplete && !notification.completed) {
             return <span className={styles.notificationIconBusy}>...</span>
         }
 

--- a/src/get-active-task-id-from-summary.js
+++ b/src/get-active-task-id-from-summary.js
@@ -1,0 +1,22 @@
+export const getActiveTaskIdFromSummary = taskSummaryResponse => {
+    const { taskId } = Object.entries(taskSummaryResponse).reduce(
+        (currLatestTask, [taskId, taskNotifications]) => {
+            // First notification is last array item, so its timestamp represents the task start
+            const firstTaskNotification =
+                taskNotifications[taskNotifications.length - 1]
+            const time = new Date(firstTaskNotification.time)
+
+            if (!taskNotifications[0].completed && time > currLatestTask.time) {
+                return { taskId, time }
+            }
+
+            return currLatestTask
+        },
+        {
+            taskId: null,
+            time: new Date(0),
+        }
+    )
+
+    return taskId
+}

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -1,4 +1,4 @@
-import { useDataMutation } from '@dhis2/app-runtime'
+import { useDataQuery, useDataMutation } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import {
     Button,
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import NotificationsTable from '../../components/NotificationsTable/NotificationsTable'
 import PageHeader from '../../components/PageHeader/PageHeader'
+import { getActiveTaskIdFromSummary } from '../../get-active-task-id-from-summary'
 import { getUpdatedNotifications } from '../../get-updated-notifications'
 import { i18nKeys } from '../../i18n-keys'
 import {
@@ -30,22 +31,35 @@ const startAnalyticsTablesGenerationMutation = {
     params: params => params,
 }
 
+const existingTasksQuery = {
+    tasks: {
+        resource: 'system/tasks/ANALYTICS_TABLE',
+    },
+}
+
 const Analytics = ({ sectionKey }) => {
     const { checkboxes, toggleCheckbox } = useCheckboxes()
     const [lastYears, setLastYears] = useState(DEFAULT_LAST_YEARS)
-    const [
-        startAnalyticsTablesGeneration,
-        { loading, error, data },
-    ] = useDataMutation(startAnalyticsTablesGenerationMutation, {
+    const poll = useAnalyticsPoll()
+    useDataQuery(existingTasksQuery, {
         onComplete: data => {
-            const { id: jobId } = data.response
-            poll.start({ jobId })
+            const taskId = getActiveTaskIdFromSummary(data.tasks)
+
+            if (taskId) {
+                poll.start({ taskId })
+            }
         },
     })
-    const poll = useAnalyticsPoll()
+    const [
+        startAnalyticsTablesGeneration,
+        { loading, error },
+    ] = useDataMutation(startAnalyticsTablesGenerationMutation, {
+        onComplete: data => {
+            const { id: taskId } = data.response
+            poll.start({ taskId })
+        },
+    })
     const notifications = poll.data ? getUpdatedNotifications(poll.data) : []
-    const isPolling =
-        data && (!poll.data || !notifications.some(n => n.completed))
 
     const handleStartAnalyticsTablesGeneration = () => {
         const params = {}
@@ -87,7 +101,7 @@ const Analytics = ({ sectionKey }) => {
                                     onChange={() => {
                                         toggleCheckbox(key)
                                     }}
-                                    disabled={loading || isPolling}
+                                    disabled={loading || poll.polling}
                                 />
                             )
                         )}
@@ -99,7 +113,7 @@ const Analytics = ({ sectionKey }) => {
                         )}
                         selected={lastYears}
                         onChange={handleLastYearsChange}
-                        disabled={loading || isPolling}
+                        disabled={loading || poll.polling}
                     >
                         {lastYearElements.map(item => (
                             <SingleSelectOption
@@ -113,9 +127,9 @@ const Analytics = ({ sectionKey }) => {
                 <Button
                     primary
                     onClick={handleStartAnalyticsTablesGeneration}
-                    disabled={loading || isPolling}
+                    disabled={loading || poll.polling}
                 >
-                    {loading || isPolling ? (
+                    {loading || poll.polling ? (
                         <>
                             {i18n.t('Exporting...')}
                             <CircularLoader small />

--- a/src/pages/analytics/Analytics.js
+++ b/src/pages/analytics/Analytics.js
@@ -49,7 +49,7 @@ const Analytics = ({ sectionKey }) => {
 
     const handleStartAnalyticsTablesGeneration = () => {
         const params = {}
-        for (const [key, checked] of Object.entries(checkboxes)) {
+        for (const [key, { checked }] of Object.entries(checkboxes)) {
             if (checked) {
                 params[key] = true
             }

--- a/src/pages/analytics/use-analytics-poll.js
+++ b/src/pages/analytics/use-analytics-poll.js
@@ -2,12 +2,12 @@ import { usePoll } from '../../hooks/use-poll'
 
 const pollQuery = {
     resource: 'system/tasks/ANALYTICS_TABLE',
-    id: ({ jobId }) => jobId,
+    id: ({ taskId }) => taskId,
 }
 
 export const useAnalyticsPoll = () =>
     usePoll({
         query: pollQuery,
         interval: 3000,
-        checkDone: data => data.some(t => t.completed),
+        checkDone: data => data[0].completed,
     })

--- a/src/pages/resource-tables/use-resource-tables-poll.js
+++ b/src/pages/resource-tables/use-resource-tables-poll.js
@@ -2,12 +2,12 @@ import { usePoll } from '../../hooks/use-poll'
 
 const pollQuery = {
     resource: 'system/tasks/RESOURCE_TABLE',
-    id: ({ jobId }) => jobId,
+    id: ({ taskId }) => taskId,
 }
 
 export const useResourceTablesPoll = () =>
     usePoll({
         query: pollQuery,
         interval: 3000,
-        checkDone: data => data.some(t => t.completed),
+        checkDone: data => data[0].completed,
     })


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-11560

Also fixes an issue where the parameters of the analytics task (e.g. `Skip generation of resource tables`) were set to true even if the user had not checked the associated checkbox.