### PR TITLE
fix: cache poll responses to prevent flickering

### DIFF
--- a/src/hooks/use-poll.js
+++ b/src/hooks/use-poll.js
@@ -29,12 +29,16 @@ const useLazyInterval = (fn, interval) => {
 }
 
 export const usePoll = ({ query, interval, checkDone }) => {
+    // Store data in state and update in onComplete as useDataQuery sets data to
+    // null when a refetch is triggered
+    const [data, setData] = useState(null)
     const wrappedQuery = useConst(() => ({
         poll: query,
     }))
-    const { refetch, error, data } = useDataQuery(wrappedQuery, {
+    const { refetch, error } = useDataQuery(wrappedQuery, {
         lazy: true,
         onComplete: data => {
+            setData(data)
             if (checkDone(data.poll)) {
                 cancel()
             }


### PR DESCRIPTION
When the `refetch` method of a `useDataQuery` is called, the associated data is set to null until the new request resolves.

This causes flickering in the analytics and resource tables pages as the data polled from the tasks endpoints is used to render a table showing the progress of the task. 