### PR TITLE
fix(data-statistics): render unlabeled rows (v36)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-08-02T09:40:17.721Z\n"
-"PO-Revision-Date: 2021-08-02T09:40:17.721Z\n"
+"POT-Creation-Date: 2022-02-06T18:57:00.335Z\n"
+"PO-Revision-Date: 2022-02-06T18:57:00.335Z\n"
 
 msgid "Data Integrity"
 msgstr ""
@@ -353,6 +353,18 @@ msgid "Data element groups"
 msgstr ""
 
 msgid "Dashboards"
+msgstr ""
+
+msgid "Visualization"
+msgstr ""
+
+msgid "Event visualization"
+msgstr ""
+
+msgid "Program instance"
+msgstr ""
+
+msgid "Tracked entity instance"
 msgstr ""
 
 msgid "Lock Exception Management"

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -234,6 +234,10 @@ export const i18nKeys = {
             chart: i18n.t('Charts'),
             dataElementGroup: i18n.t('Data element groups'),
             dashboard: i18n.t('Dashboards'),
+            visualization: i18n.t('Visualization'),
+            eventVisualization: i18n.t('Event visualization'),
+            programInstance: i18n.t('Program instance'),
+            trackedEntityInstance: i18n.t('Tracked entity instance'),
         },
     },
     lockException: {

--- a/src/pages/data-statistics/DataStatistics.js
+++ b/src/pages/data-statistics/DataStatistics.js
@@ -47,10 +47,14 @@ class DataStatistics extends Page {
             for (let i = 0; i < objectCountsKeys.length; i++) {
                 const key = objectCountsKeys[i]
                 objectCountsTable.elements.push({
-                    label: i18n.t(i18nKeys.dataStatistics.objects[key]),
+                    label: i18n.t(i18nKeys.dataStatistics.objects[key] || key),
                     count: objectCountsResponse[key],
                 })
             }
+
+            objectCountsTable.elements.sort((a, b) =>
+                a.label.localeCompare(b.label)
+            )
 
             return objectCountsTable
         }


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10785

Adds fallback for data statistics row labels and adds i18n keys for `visualization`, `eventVisualization`, `programInstance` and `trackedEntityInstance` object types.