### PR TITLE
fix: always use latest refetch from useDataQuery using ref

### DIFF
--- a/src/hooks/use-poll.js
+++ b/src/hooks/use-poll.js
@@ -10,6 +10,8 @@ const useConst = factory => {
 }
 
 const useLazyInterval = (fn, interval) => {
+    const fnRef = useRef()
+    fnRef.current = fn
     const intervalId = useRef(null)
     const [started, setStarted] = useState(false)
 
@@ -21,7 +23,7 @@ const useLazyInterval = (fn, interval) => {
     }
     const start = (...args) => {
         cancel()
-        intervalId.current = setInterval(() => fn(...args), interval)
+        intervalId.current = setInterval(() => fnRef.current(...args), interval)
         setStarted(true)
     }
 


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-12775

In https://github.com/dhis2/data-administration-app/pull/750, we bumped `@dhis2/app-runtime` to a version that included the changes made in https://github.com/dhis2/app-runtime/pull/1086. The changes from the latter PR mean that it is no longer safe (in the sense that `refetch` does not behave as expected) to assume that the `refetch` function returned by a `useDataQuery` hook will be constant thoughout the lifetime of a component.

This assumption has been fixed by having the `useLazyInterval` hook assume that its first argument (the function to run in the interval) can change.