### PR TITLE
fix: support multiple org unit roots

### DIFF
--- a/src/hooks/use-user-organisation-units.js
+++ b/src/hooks/use-user-organisation-units.js
@@ -1,0 +1,57 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import { useEffect } from 'react'
+
+const currentUserQuery = {
+    currentUser: {
+        resource: 'me',
+        params: {
+            fields: ['organisationUnits', 'authorities'],
+        },
+    },
+}
+
+const allRootsQuery = {
+    allRoots: {
+        resource: 'organisationUnits',
+        params: {
+            filter: 'level:eq:1',
+            fields: 'id',
+            paging: 'false',
+        },
+    },
+}
+
+export const useUserOrganisationUnits = () => {
+    const { loading, data, error } = useDataQuery(currentUserQuery)
+    const {
+        called: calledAll,
+        loading: loadingAll,
+        data: dataAll,
+        error: errorAll,
+        refetch,
+    } = useDataQuery(allRootsQuery, { lazy: true })
+
+    useEffect(() => {
+        if (
+            !(data?.currentUser.organisationUnits.length > 0) &&
+            data?.currentUser?.authorities.includes('ALL')
+        ) {
+            //fetch all orgs
+            refetch()
+        }
+    }, [data])
+
+    if (calledAll) {
+        return {
+            loading: loadingAll,
+            error: errorAll,
+            organisationUnits: dataAll?.allRoots.organisationUnits,
+        }
+    }
+
+    return {
+        loading,
+        error,
+        organisationUnits: data?.currentUser.organisationUnits,
+    }
+}

--- a/src/pages/min-max-value-generation/use-queries.js
+++ b/src/pages/min-max-value-generation/use-queries.js
@@ -1,0 +1,32 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import { useUserOrganisationUnits } from '../../hooks/use-user-organisation-units'
+
+const dataSetsQuery = {
+    dataSets: {
+        resource: 'dataSets',
+        params: {
+            fields: ['id', 'displayName'],
+            paging: false,
+        },
+    },
+}
+
+export const useQueries = () => {
+    const {
+        loading: loadingOrgUnits,
+        error: errorOrgUnits,
+        organisationUnits,
+    } = useUserOrganisationUnits()
+    const {
+        loading: loadingDataSets,
+        error: errorDataSets,
+        data,
+    } = useDataQuery(dataSetsQuery)
+
+    return {
+        loading: loadingOrgUnits || loadingDataSets,
+        error: errorOrgUnits || errorDataSets,
+        organisationUnits,
+        dataSets: data?.dataSets.dataSets,
+    }
+}


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-12987

TODO:

- [ ] Fix 'Add lock exception' page
  - Fix will need to be in [OrganisationUnitSelection component](https://github.com/dhis2/data-administration-app/blob/master/src/pages/add-lock-exception/AddLockExceptionForm/OrganisationUnitSelection/OrganisationUnitSelection.js)
  - Difficulty in creating a fix is due to the [‘memberCollection’ and ‘memberObject’ params](https://github.com/dhis2/data-administration-app/blob/master/src/pages/add-lock-exception/AddLockExceptionForm/OrganisationUnitSelection/OrganisationUnitSelection.js#L31-L32)
     - In order to get the current user’s org unit roots, we need to use /api/me — however I don’t think that endpoint supports passing memberCollection and memberObject params
     - Not 100% sure what these params do, but maybe it’s possible to first use /api/me to get org units and then use /api/organisationUnits with filtering (using filter param) by the IDs returned by /api/me?