### PR TITLE
fix(analytics-tables): prevent excessive table width for long strings

### DIFF
--- a/src/components/NotificationsTable/NotificationsTable.js
+++ b/src/components/NotificationsTable/NotificationsTable.js
@@ -45,7 +45,9 @@ const NotificationsTable = ({ notifications }) => {
                                 {formatDateFromServer(notification.time)}
                             </TableCell>
                             <TableCell>
-                                {notification.message}{' '}
+                                <span className={styles.message}>
+                                    {notification.message}
+                                </span>{' '}
                                 {renderNotificationIcon(notification)}
                             </TableCell>
                         </TableRow>

--- a/src/components/NotificationsTable/NotificationsTable.module.css
+++ b/src/components/NotificationsTable/NotificationsTable.module.css
@@ -10,6 +10,10 @@
     width: 0px;
 }
 
+.message {
+    word-break: break-word;
+}
+
 @keyframes ellipsis {
     to {
         width: 14px;


### PR DESCRIPTION
Fixes [DHIS2-13118](https://jira.dhis2.org/browse/DHIS2-13118). Also see [this](https://dhis2.slack.com/archives/CPGUFVC56/p1650455935436329) Slack thread.

The issue was not caused by long log messages per se, but very long "words" i.e. sequences of characters not interrupted by spaces. So to resolve it I had to resort to wrapping the message in a `span` with `word-break: break-word;`. Things would now look like this:
<img width="987" alt="Screenshot 2022-04-20 at 14 45 59" src="https://user-images.githubusercontent.com/353236/164234686-e6b1e191-d838-4fdb-b97b-7709d758c48a.png">

