### PR TITLE
fix(lock exception): remove text underline from top-right buttons

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-02T11:44:10.658Z\n"
-"PO-Revision-Date: 2022-03-02T11:44:10.658Z\n"
+"POT-Creation-Date: 2023-03-09T00:41:03.216Z\n"
+"PO-Revision-Date: 2023-03-09T00:41:03.216Z\n"
 
 msgid "Open user guide"
 msgstr "Open user guide"
@@ -206,6 +206,9 @@ msgstr "Skip generation of event data"
 
 msgid "Skip generation of enrollment data"
 msgstr "Skip generation of enrollment data"
+
+msgid "Skip generation of organisation unit ownership data"
+msgstr "Skip generation of organisation unit ownership data"
 
 msgid "Data Statistics"
 msgstr "Data Statistics"

--- a/src/pages/lock-exceptions/LockExceptions.js
+++ b/src/pages/lock-exceptions/LockExceptions.js
@@ -93,10 +93,18 @@ const LockExceptions = ({ sectionKey }) => {
                     title={i18nKeys.lockExceptions.title}
                 />
                 <ButtonStrip>
-                    <Link to="/lock-exceptions/add" tabIndex="-1">
+                    <Link
+                        className={styles.linkButton}
+                        to="/lock-exceptions/add"
+                        tabIndex="-1"
+                    >
                         <Button primary>{i18n.t('Add lock exception')}</Button>
                     </Link>
-                    <Link to="/lock-exceptions/batch-deletion" tabIndex="-1">
+                    <Link
+                        className={styles.linkButton}
+                        to="/lock-exceptions/batch-deletion"
+                        tabIndex="-1"
+                    >
                         <Button>{i18n.t('Batch deletion')}</Button>
                     </Link>
                 </ButtonStrip>

--- a/src/pages/lock-exceptions/LockExceptions.module.css
+++ b/src/pages/lock-exceptions/LockExceptions.module.css
@@ -8,3 +8,7 @@
     justify-content: space-between;
     margin-bottom: var(--spacers-dp16);
 }
+
+.linkButton {
+    text-decoration: none;
+}


### PR DESCRIPTION
Backports: #905 

Before:
![image](https://user-images.githubusercontent.com/10101831/223887273-5ccc2b14-ed90-4845-9389-f4364b8326d5.png)

After:
![image](https://user-images.githubusercontent.com/10101831/223887298-343888d7-2b8b-4a2e-84bc-0dd8c89f10a0.png)