### PR TITLE
fix: align docs section with updates to master docs [BETA-24]

### DIFF
--- a/src/pages/sections.conf.js
+++ b/src/pages/sections.conf.js
@@ -82,7 +82,7 @@ export const sections = [
             label: i18nKeys.minMaxValueGeneration.label,
             description: i18nKeys.minMaxValueGeneration.description,
             actionText: i18nKeys.minMaxValueGeneration.actionText,
-            docs: 'dataAdmin_minMaxValueGeneration',
+            docs: 'data_admin_min_max_value_generation',
         },
     },
 ]


### PR DESCRIPTION
simple change to align with recent changes to docs.

This is not very important, but it is zero risk, and it closes an issue raised in beta testing.