### PR TITLE
fix: last years missing valid value of 0

### DIFF
--- a/src/pages/analytics/analytics.conf.js
+++ b/src/pages/analytics/analytics.conf.js
@@ -5,7 +5,7 @@ export const DEFAULT_LAST_YEARS = '-1'
 export const LAST_YEARS_INPUT_KEY = 'lastYears'
 
 const LAST_YEAR = 10
-const FIRST_YEAR = 1
+const FIRST_YEAR = 0
 
 const lastYearValues = [
     {


### PR DESCRIPTION
In `dhis-web-data-administration/index.html#/analytics`, there is a dropdown for "Number of last years of data to include".  It starts at 1, but 0 is a valid value that leads to calculating analytics for all changed values since the last analytics update.

This PR adds that value to the menu.