### PR TITLE
fix: clean up resource tables section [DHIS2-16445]

### DIFF
--- a/src/i18n-keys.js
+++ b/src/i18n-keys.js
@@ -59,9 +59,6 @@ export const i18nKeys = {
         ),
         tables: {
             organisationUnitStructure: i18n.t('Organisation unit structure'),
-            organistionUnitCategoryOptionCombo: i18n.t(
-                'Organisation unit category option combo'
-            ),
             categoryOptionGroupSetStructure: i18n.t(
                 'Category option group set structure'
             ),
@@ -81,6 +78,9 @@ export const i18nKeys = {
             dataPeriodStructure: i18n.t('Date period structure'),
             dataElementCategoryOptionCombinations: i18n.t(
                 'Data element category option combinations'
+            ),
+            dataSetOrganisationUnitCategory: i18n.t(
+                'Data set organisation unit category'
             ),
         },
     },

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -11,51 +11,47 @@ import { useResourceTables } from './use-resource-tables.js'
 const tables = [
     {
         key: 'organisationUnitStructure',
-        name: '_orgunitstructure',
-    },
-    {
-        key: 'organistionUnitCategoryOptionCombo',
-        name: '_orgunitstructure',
-    },
-    {
-        key: 'categoryOptionGroupSetStructure',
-        name: '_categoryoptiongroupsetstructure',
+        name: 'analytics_rs_orgunitstructure',
     },
     {
         key: 'dataElementGroupSetStructure',
-        name: '_dataelementgroupsetstructure',
+        name: 'analytics_rs_dataelementgroupsetstructure',
     },
     {
         key: 'indicatorGroupSetStructure',
-        name: '_indicatorgroupsetstructure',
+        name: 'analytics_rs_indicatorgroupsetstructure',
     },
     {
         key: 'organisationUnitGroupSetStructure',
-        name: '_organisationunitgroupsetstructure',
+        name: 'analytics_rs_organisationunitgroupsetstructure',
     },
     {
         key: 'categoryStructure',
-        name: '_categorystructure',
+        name: 'analytics_rs_categorystructure',
     },
     {
         key: 'dataElementCategoryOptionComboName',
-        name: '_categoryoptioncomboname',
+        name: 'analytics_rs_categoryoptioncomboname',
     },
     {
         key: 'dataElementStructure',
-        name: '_dataelementstructure',
-    },
-    {
-        key: 'periodStructure',
-        name: '_periodstructure',
+        name: 'analytics_rs_dataelementstructure',
     },
     {
         key: 'dataPeriodStructure',
-        name: '_dateperiodstructure',
+        name: 'analytics_rs_dateperiodstructure',
+    },
+    {
+        key: 'periodStructure',
+        name: 'analytics_rs_periodstructure',
     },
     {
         key: 'dataElementCategoryOptionCombinations',
-        name: '_dataelementcategoryoptioncombo',
+        name: 'analytics_rs_dataelementcategoryoptioncombo',
+    },
+    {
+        key: 'dataSetOrganisationUnitCategory',
+        name: 'analytics_rs_datasetorganisationunitcategory',
     },
 ]
 

--- a/src/pages/sections.conf.js
+++ b/src/pages/sections.conf.js
@@ -16,7 +16,7 @@ export const sections = [
             label: i18nKeys.dataIntegrity.label,
             description: i18nKeys.dataIntegrity.description,
             actionText: i18nKeys.dataIntegrity.actionText,
-            docs: 'dataAdmin_dataIntegrity',
+            docs: 'data_admin_data_integrity',
             fullscreen: true,
         },
     },
@@ -39,7 +39,7 @@ export const sections = [
             label: i18nKeys.resourceTables.label,
             description: i18nKeys.resourceTables.description,
             actionText: i18nKeys.resourceTables.actionText,
-            docs: 'dataAdmin_resourceTables',
+            docs: 'data_admin_resource_tables',
         },
     },
     {
@@ -50,7 +50,7 @@ export const sections = [
             label: i18nKeys.analytics.label,
             description: i18nKeys.analytics.description,
             actionText: i18nKeys.analytics.actionText,
-            docs: 'analytics_tables_management',
+            docs: 'data_admin_analytics_tables',
         },
     },
     {
@@ -61,7 +61,7 @@ export const sections = [
             label: i18nKeys.dataStatistics.label,
             description: i18nKeys.dataStatistics.description,
             actionText: i18nKeys.dataStatistics.actionText,
-            docs: 'dataAdmin_dataStatistics',
+            docs: 'data_admin__data_statistics',
         },
     },
     {
@@ -72,7 +72,7 @@ export const sections = [
             label: i18nKeys.lockExceptions.label,
             description: i18nKeys.lockExceptions.description,
             actionText: i18nKeys.lockExceptions.actionText,
-            docs: 'dataAdmin_lockException',
+            docs: 'data_admin__lock_exception',
         },
     },
     {
@@ -83,7 +83,7 @@ export const sections = [
             label: i18nKeys.minMaxValueGeneration.label,
             description: i18nKeys.minMaxValueGeneration.description,
             actionText: i18nKeys.minMaxValueGeneration.actionText,
-            docs: 'dataAdmin_minMaxValueGeneration',
+            docs: 'data_admin_min_max_value_generation',
         },
     },
 ]


### PR DESCRIPTION
This cleans up the Resource tables page and reflects the recent changes in documentation:
- removes a duplicate table (Organisation unit category option combo) and adds missing Data set organisation unit category
- updates table names to v41, v42 versions (`analytics_rs_orgunitstructure` instead of `_orgunitstructure`
- fixes links (I cleaned up these in general because it seems the documentation was updated and now most of them were just pointing to data administration generally)

(See https://github.com/dhis2/dhis2-docs/pull/1417 and https://github.com/dhis2/dhis2-docs/pull/1416)

**Before**
<img width="769" alt="image" src="https://github.com/user-attachments/assets/924baffb-ae23-4818-b6c7-4e9af1861edb">


**After**
<img width="826" alt="image" src="https://github.com/user-attachments/assets/9654b2fb-653a-4564-8e6e-d6334da98a53">

**Testing**
I've manually tested (as it's essentially just text cleanup) and compared against documentation PRs.