### PR TITLE
fix: clean up resources page [DHIS2-16445] v39

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-02T11:44:10.658Z\n"
-"PO-Revision-Date: 2022-03-02T11:44:10.658Z\n"
+"POT-Creation-Date: 2024-07-15T12:15:07.265Z\n"
+"PO-Revision-Date: 2024-07-15T12:15:07.265Z\n"
 
 msgid "Open user guide"
 msgstr "Open user guide"
@@ -143,9 +143,6 @@ msgstr "An unexpected error happened during operation"
 msgid "Organisation unit structure"
 msgstr "Organisation unit structure"
 
-msgid "Organisation unit category option combo"
-msgstr "Organisation unit category option combo"
-
 msgid "Category option group set structure"
 msgstr "Category option group set structure"
 
@@ -175,6 +172,9 @@ msgstr "Date period structure"
 
 msgid "Data element category option combinations"
 msgstr "Data element category option combinations"
+
+msgid "Data set organisation unit category"
+msgstr "Data set organisation unit category"
 
 msgid "Analytics tables management"
 msgstr "Analytics tables management"

--- a/src/i18n-keys.js
+++ b/src/i18n-keys.js
@@ -59,9 +59,6 @@ export const i18nKeys = {
         ),
         tables: {
             organisationUnitStructure: i18n.t('Organisation unit structure'),
-            organistionUnitCategoryOptionCombo: i18n.t(
-                'Organisation unit category option combo'
-            ),
             categoryOptionGroupSetStructure: i18n.t(
                 'Category option group set structure'
             ),
@@ -81,6 +78,9 @@ export const i18nKeys = {
             dataPeriodStructure: i18n.t('Date period structure'),
             dataElementCategoryOptionCombinations: i18n.t(
                 'Data element category option combinations'
+            ),
+            dataSetOrganisationUnitCategory: i18n.t(
+                'Data set organisation unit category'
             ),
         },
     },

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -11,51 +11,47 @@ import { useResourceTables } from './use-resource-tables.js'
 const tables = [
     {
         key: 'organisationUnitStructure',
-        name: '_orgunitstructure',
-    },
-    {
-        key: 'organistionUnitCategoryOptionCombo',
-        name: '_orgunitstructure',
-    },
-    {
-        key: 'categoryOptionGroupSetStructure',
-        name: '_categoryoptiongroupsetstructure',
+        name: 'analytics_rs_orgunitstructure',
     },
     {
         key: 'dataElementGroupSetStructure',
-        name: '_dataelementgroupsetstructure',
+        name: 'analytics_rs_dataelementgroupsetstructure',
     },
     {
         key: 'indicatorGroupSetStructure',
-        name: '_indicatorgroupsetstructure',
+        name: 'analytics_rs_indicatorgroupsetstructure',
     },
     {
         key: 'organisationUnitGroupSetStructure',
-        name: '_organisationunitgroupsetstructure',
+        name: 'analytics_rs_organisationunitgroupsetstructure',
     },
     {
         key: 'categoryStructure',
-        name: '_categorystructure',
+        name: 'analytics_rs_categorystructure',
     },
     {
         key: 'dataElementCategoryOptionComboName',
-        name: '_categoryoptioncomboname',
+        name: 'analytics_rs_categoryoptioncomboname',
     },
     {
         key: 'dataElementStructure',
-        name: '_dataelementstructure',
-    },
-    {
-        key: 'periodStructure',
-        name: '_periodstructure',
+        name: 'analytics_rs_dataelementstructure',
     },
     {
         key: 'dataPeriodStructure',
-        name: '_dateperiodstructure',
+        name: 'analytics_rs_dateperiodstructure',
+    },
+    {
+        key: 'periodStructure',
+        name: 'analytics_rs_periodstructure',
     },
     {
         key: 'dataElementCategoryOptionCombinations',
-        name: '_dataelementcategoryoptioncombo',
+        name: 'analytics_rs_dataelementcategoryoptioncombo',
+    },
+    {
+        key: 'dataSetOrganisationUnitCategory',
+        name: 'analytics_rs_datasetorganisationunitcategory',
     },
 ]
 

--- a/src/pages/resource-tables/ResourceTables.js
+++ b/src/pages/resource-tables/ResourceTables.js
@@ -11,47 +11,47 @@ import { useResourceTables } from './use-resource-tables.js'
 const tables = [
     {
         key: 'organisationUnitStructure',
-        name: 'analytics_rs_orgunitstructure',
+        name: '_orgunitstructure',
     },
     {
         key: 'dataElementGroupSetStructure',
-        name: 'analytics_rs_dataelementgroupsetstructure',
+        name: '_dataelementgroupsetstructure',
     },
     {
         key: 'indicatorGroupSetStructure',
-        name: 'analytics_rs_indicatorgroupsetstructure',
+        name: '_indicatorgroupsetstructure',
     },
     {
         key: 'organisationUnitGroupSetStructure',
-        name: 'analytics_rs_organisationunitgroupsetstructure',
+        name: '_organisationunitgroupsetstructure',
     },
     {
         key: 'categoryStructure',
-        name: 'analytics_rs_categorystructure',
+        name: '_categorystructure',
     },
     {
         key: 'dataElementCategoryOptionComboName',
-        name: 'analytics_rs_categoryoptioncomboname',
+        name: '_categoryoptioncomboname',
     },
     {
         key: 'dataElementStructure',
-        name: 'analytics_rs_dataelementstructure',
+        name: '_dataelementstructure',
     },
     {
         key: 'dataPeriodStructure',
-        name: 'analytics_rs_dateperiodstructure',
+        name: '_dateperiodstructure',
     },
     {
         key: 'periodStructure',
-        name: 'analytics_rs_periodstructure',
+        name: '_periodstructure',
     },
     {
         key: 'dataElementCategoryOptionCombinations',
-        name: 'analytics_rs_dataelementcategoryoptioncombo',
+        name: '_dataelementcategoryoptioncombo',
     },
     {
         key: 'dataSetOrganisationUnitCategory',
-        name: 'analytics_rs_datasetorganisationunitcategory',
+        name: '_datasetorganisationunitcategory',
     },
 ]
 

--- a/src/pages/sections.conf.js
+++ b/src/pages/sections.conf.js
@@ -16,7 +16,7 @@ export const sections = [
             label: i18nKeys.dataIntegrity.label,
             description: i18nKeys.dataIntegrity.description,
             actionText: i18nKeys.dataIntegrity.actionText,
-            docs: 'dataAdmin_dataIntegrity',
+            docs: 'data_admin_data_integrity',
         },
     },
     {
@@ -38,7 +38,7 @@ export const sections = [
             label: i18nKeys.resourceTables.label,
             description: i18nKeys.resourceTables.description,
             actionText: i18nKeys.resourceTables.actionText,
-            docs: 'dataAdmin_resourceTables',
+            docs: 'data_admin_resource_tables',
         },
     },
     {
@@ -49,7 +49,7 @@ export const sections = [
             label: i18nKeys.analytics.label,
             description: i18nKeys.analytics.description,
             actionText: i18nKeys.analytics.actionText,
-            docs: 'analytics_tables_management',
+            docs: 'data_admin_analytics_tables',
         },
     },
     {
@@ -60,7 +60,7 @@ export const sections = [
             label: i18nKeys.dataStatistics.label,
             description: i18nKeys.dataStatistics.description,
             actionText: i18nKeys.dataStatistics.actionText,
-            docs: 'dataAdmin_dataStatistics',
+            docs: 'data_admin__data_statistics',
         },
     },
     {
@@ -71,7 +71,7 @@ export const sections = [
             label: i18nKeys.lockExceptions.label,
             description: i18nKeys.lockExceptions.description,
             actionText: i18nKeys.lockExceptions.actionText,
-            docs: 'dataAdmin_lockException',
+            docs: 'data_admin__lock_exception',
         },
     },
     {
@@ -82,7 +82,7 @@ export const sections = [
             label: i18nKeys.minMaxValueGeneration.label,
             description: i18nKeys.minMaxValueGeneration.description,
             actionText: i18nKeys.minMaxValueGeneration.actionText,
-            docs: 'dataAdmin_minMaxValueGeneration',
+            docs: 'data_admin_min_max_value_generation',
         },
     },
 ]


### PR DESCRIPTION
This is essentially a backport of https://github.com/dhis2/data-administration-app/pull/1055

Note that in v39, the table names are in the "old" format (`_orgunitstructure`, not `analytics_rs_orgunitstructure`). Also note that documentation links direct you to current version's docs, but I believe this is by design as eventually the docs for older versions can be removed (I think I asked Phil about this once before).

Corresponds to this documentation PR: https://github.com/dhis2/dhis2-docs/pull/1414