### PR TITLE
fix: force current params [DHIS2-17758]

### DIFF
--- a/src/pages/maintenance/Maintenance.js
+++ b/src/pages/maintenance/Maintenance.js
@@ -12,7 +12,7 @@ import { useCheckboxes } from './use-checkboxes.js'
 const mutation = {
     resource: 'maintenance',
     type: 'create',
-    params: (params) => params,
+    params: ({ params }) => params,
 }
 
 const Maintenance = ({ sectionKey }) => {
@@ -32,7 +32,7 @@ const Maintenance = ({ sectionKey }) => {
                 params[key] = true
             }
         }
-        mutate(params)
+        mutate({ params })
     }
 
     return (


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-17758

### Issue
The issue here was that previous selections under Maintenance page were persisted in query even after you unclicked them. E.g. if you selected "Prune periods", executed the query, then selected "Removed expired invitations" and unclicked "Prune periods", the query would be api/maintenance?prunePeriods=true&expiredInvitationsClear=true.

This is caused by logic in app-runtime whereby variables on subsequent mutation executions are added to the previous variables: https://github.com/dhis2/app-runtime/blob/master/services/data/src/react/hooks/useQueryExecutor.ts#L58-L61.

I don't know the reasoning behind that logic (i.e. it might be by design), so for now, I am fixing the immediate issue in the app by passing `params` as an object to variables, e.g. `{params: {prunePeriods: true, expiredInvitationsClear: true}}` rather than as individual arguments (i.e. currently we pass like (`{prunePeriods: true, expiredInvitationsClear: true}`). Specifying params as an object allows it to be overwritten fully on subsequent mutation executions, which means that we do not get the previous "true" values hanging around.

### Testing
*automated*: we only have one test in this app, and I do not want to add additional here (particularly as this solution currently feels also like a workaround useDataMutation logic).
*manual*: tested with local version of the app checking/unchecking various options to make sure that request reflects the checked values show in the UI.