### PR TITLE
fix: reference master docs [DHIS2-16445]

### DIFF
--- a/src/components/DocsLink/DocsLink.js
+++ b/src/components/DocsLink/DocsLink.js
@@ -1,4 +1,3 @@
-import { useConfig } from '@dhis2/app-runtime'
 import { colors, Tooltip, IconQuestion24 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -6,16 +5,9 @@ import i18n from '../../locales/index.js'
 import { getDocsKeyForSection } from '../../pages/sections.conf.js'
 import styles from './DocsLink.module.css'
 
-const getDocsVersion = ({ major, minor, tag }) => {
-    if (tag === 'SNAPSHOT') {
-        return 'master'
-    }
-    return `${major}${minor}`
-}
-
 const DocsLink = ({ sectionKey }) => {
-    const { serverVersion } = useConfig()
-    const docsVersion = getDocsVersion(serverVersion)
+    // by default, use 'master' to prevent links to expired / removed docs
+    const docsVersion = 'master'
     const docsKey = getDocsKeyForSection(sectionKey)
 
     return (


### PR DESCRIPTION
This PR sets the links used in the data administration app to always reference the `master` version.

From Phil:
> Yes, as long as we reference central documentation it is best to reference the master version.

Lina noticed that the link was inconsistent when reviewing the original ticket (https://dhis2.atlassian.net/browse/DHIS2-16445?focusedCommentId=200012). 